### PR TITLE
Change request a wrong substrate interface.

### DIFF
--- a/src/substrate_query_interface.js
+++ b/src/substrate_query_interface.js
@@ -96,7 +96,7 @@ async function getStakingCurrentElected(api) {
 
 async function getStakingStakers(api, accountAddress) {
     return await Promise.race([
-        api.query.staking.stakers(accountAddress),
+        api.query.staking.nominators(accountAddress),
         Timeout.set(TIMEOUT_TIME_MS, 'API call staking/stakers failed.')]);
 }
 


### PR DESCRIPTION
If use `api.query.staking.stakers` the method return this:
`{"error":"TypeError: api.query.staking.stakers is not a function"}`
https://polkadot.js.org/api/substrate/storage.html#nominators-accountid-option-nominations